### PR TITLE
refactor: rename crate to `workos`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "workos-sdk"
+name = "workos"
 version = "0.4.1"
 dependencies = [
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "workos-sdk"
+name = "workos"
 version = "0.4.1"
 description = "Rust SDK for interacting with the WorkOS API."
 repository = "https://github.com/RustForWeb/workos"

--- a/README.md
+++ b/README.md
@@ -1,19 +1,8 @@
-# WARNING: Crate moved
-
-This crate has moved to [`workos`](https://crates.io/crates/workos). Please upgrade by changing the crate name in `Cargo.toml`:
-
-```diff
-- workos-sdk = "0.4.1"
-+ workos = "0.5.0"
-```
-
----
-
 # WorkOS Rust SDK
 
-[![Crates.io](https://img.shields.io/crates/v/workos-sdk.svg)](https://crates.io/crates/workos-sdk)
-[![Docs.rs](https://docs.rs/workos-sdk/badge.svg)](https://docs.rs/workos-sdk/)
-[![License](https://img.shields.io/crates/l/workos-sdk.svg)](https://github.com/RustForWeb/workos/blob/main/LICENSE)
+[![Crates.io](https://img.shields.io/crates/v/workos.svg)](https://crates.io/crates/workos)
+[![Docs.rs](https://docs.rs/workos/badge.svg)](https://docs.rs/workos/)
+[![License](https://img.shields.io/crates/l/workos.svg)](https://github.com/RustForWeb/workos/blob/main/LICENSE.md)
 
 The WorkOS library for Rust provides convenient access to the WorkOS API from applications written in Rust.
 
@@ -21,7 +10,7 @@ The WorkOS library for Rust provides convenient access to the WorkOS API from ap
 
 Documentation for the crate is available on [Docs.rs](https://docs.rs/):
 
-- [`workos-sdk`](https://docs.rs/workos-sdk/latest/workos_sdk/)
+- [`workos`](https://docs.rs/workos/latest/workos/)
 
 ## Credits
 

--- a/src/admin_portal/operations/generate_portal_link.rs
+++ b/src/admin_portal/operations/generate_portal_link.rs
@@ -66,10 +66,10 @@ pub trait GeneratePortalLink {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::admin_portal::*;
-    /// # use workos_sdk::organizations::OrganizationId;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::admin_portal::*;
+    /// # use workos::organizations::OrganizationId;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GeneratePortalLinkError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/directory_sync/operations/delete_directory.rs
+++ b/src/directory_sync/operations/delete_directory.rs
@@ -32,9 +32,9 @@ pub trait DeleteDirectory {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::directory_sync::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::directory_sync::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), DeleteDirectoryError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/directory_sync/operations/get_directory.rs
+++ b/src/directory_sync/operations/get_directory.rs
@@ -24,9 +24,9 @@ pub trait GetDirectory {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::directory_sync::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::directory_sync::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetDirectoryError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/directory_sync/operations/get_directory_group.rs
+++ b/src/directory_sync/operations/get_directory_group.rs
@@ -24,9 +24,9 @@ pub trait GetDirectoryGroup {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::directory_sync::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::directory_sync::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetDirectoryGroupError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/directory_sync/operations/get_directory_user.rs
+++ b/src/directory_sync/operations/get_directory_user.rs
@@ -24,9 +24,9 @@ pub trait GetDirectoryUser {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::directory_sync::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::directory_sync::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetDirectoryUserError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/directory_sync/operations/list_directories.rs
+++ b/src/directory_sync/operations/list_directories.rs
@@ -36,9 +36,9 @@ pub trait ListDirectories {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::directory_sync::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::directory_sync::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), ()> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/directory_sync/operations/list_directory_groups.rs
+++ b/src/directory_sync/operations/list_directory_groups.rs
@@ -41,9 +41,9 @@ pub trait ListDirectoryGroups {
     /// [WorkOS Docs: List Directory Groups](https://workos.com/docs/reference/directory-sync/group/list)
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::directory_sync::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::directory_sync::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), ()> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/directory_sync/operations/list_directory_users.rs
+++ b/src/directory_sync/operations/list_directory_users.rs
@@ -41,9 +41,9 @@ pub trait ListDirectoryUsers {
     /// [WorkOS Docs: List Directory Users](https://workos.com/docs/reference/directory-sync/user/list)
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::directory_sync::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::directory_sync::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), ()> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/events/operations/list_events.rs
+++ b/src/events/operations/list_events.rs
@@ -63,9 +63,9 @@ pub trait ListEvents {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::events::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::events::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), ()> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,4 @@
 //! Rust SDK for interacting with the [WorkOS](https://workos.com) API.
-//!
-//! # WARNING: Crate moved
-//!
-//! This crate has moved to [`workos`](https://crates.io/crates/workos). Please upgrade by changing the crate name in `Cargo.toml`:
-//!
-//! ```diff
-//! - workos-sdk = "0.4.1"
-//! + workos = "0.5.0"
-//! ```
 
 #![warn(missing_docs)]
 

--- a/src/mfa/operations/challenge_factor.rs
+++ b/src/mfa/operations/challenge_factor.rs
@@ -49,9 +49,9 @@ pub trait ChallengeFactor {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::mfa::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::mfa::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), ChallengeFactorError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/mfa/operations/enroll_factor.rs
+++ b/src/mfa/operations/enroll_factor.rs
@@ -98,9 +98,9 @@ pub trait EnrollFactor {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::mfa::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::mfa::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), EnrollFactorError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/mfa/operations/verify_challenge.rs
+++ b/src/mfa/operations/verify_challenge.rs
@@ -41,9 +41,9 @@ pub trait VerifyChallenge {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::mfa::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::mfa::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), VerifyChallengeError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/organizations/operations/create_organization.rs
+++ b/src/organizations/operations/create_organization.rs
@@ -49,9 +49,9 @@ pub trait CreateOrganization {
     /// ```
     /// use std::collections::HashSet;
     ///
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::organizations::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::organizations::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), CreateOrganizationError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/organizations/operations/delete_organization.rs
+++ b/src/organizations/operations/delete_organization.rs
@@ -32,9 +32,9 @@ pub trait DeleteOrganization {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::organizations::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::organizations::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), DeleteOrganizationError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/organizations/operations/get_organization.rs
+++ b/src/organizations/operations/get_organization.rs
@@ -24,9 +24,9 @@ pub trait GetOrganization {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::organizations::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::organizations::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetOrganizationError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/organizations/operations/list_organizations.rs
+++ b/src/organizations/operations/list_organizations.rs
@@ -49,9 +49,9 @@ pub trait ListOrganizations {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::organizations::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::organizations::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), ()> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/organizations/operations/update_organization.rs
+++ b/src/organizations/operations/update_organization.rs
@@ -53,9 +53,9 @@ pub trait UpdateOrganization {
     /// ```
     /// use std::collections::HashSet;
     ///
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::organizations::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::organizations::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), UpdateOrganizationError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/passwordless/operations/create_passwordless_session.rs
+++ b/src/passwordless/operations/create_passwordless_session.rs
@@ -48,9 +48,9 @@ pub trait CreatePasswordlessSession {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::passwordless::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::passwordless::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), CreatePasswordlessSessionError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/passwordless/operations/send_passwordless_session.rs
+++ b/src/passwordless/operations/send_passwordless_session.rs
@@ -25,9 +25,9 @@ pub trait SendPasswordlessSession {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::passwordless::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::passwordless::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), SendPasswordlessSessionError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/sso/operations/delete_connection.rs
+++ b/src/sso/operations/delete_connection.rs
@@ -32,9 +32,9 @@ pub trait DeleteConnection {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), DeleteConnectionError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/sso/operations/get_authorization_url.rs
+++ b/src/sso/operations/get_authorization_url.rs
@@ -54,8 +54,8 @@ pub trait GetAuthorizationUrl {
     ///
     /// ```
     /// # use url::ParseError;
-    /// # use workos_sdk::sso::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::sso::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # fn run() -> Result<(), ParseError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/sso/operations/get_connection.rs
+++ b/src/sso/operations/get_connection.rs
@@ -24,9 +24,9 @@ pub trait GetConnection {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetConnectionError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/sso/operations/get_profile.rs
+++ b/src/sso/operations/get_profile.rs
@@ -16,9 +16,9 @@ pub trait GetProfile {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetProfileError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/sso/operations/get_profile_and_token.rs
+++ b/src/sso/operations/get_profile_and_token.rs
@@ -78,9 +78,9 @@ pub trait GetProfileAndToken {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetProfileAndTokenError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/sso/operations/list_connections.rs
+++ b/src/sso/operations/list_connections.rs
@@ -30,9 +30,9 @@ pub trait ListConnections {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), ()> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/accept_invitation.rs
+++ b/src/user_management/operations/accept_invitation.rs
@@ -24,9 +24,9 @@ pub trait AcceptInvitation {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), AcceptInvitationError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/authenticate_with_code.rs
+++ b/src/user_management/operations/authenticate_with_code.rs
@@ -55,10 +55,10 @@ pub trait AuthenticateWithCode {
     /// ```
     /// # use std::{net::IpAddr, str::FromStr};
     ///
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::{AuthorizationCode, ClientId};
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::{AuthorizationCode, ClientId};
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), AuthenticateError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/authenticate_with_email_verification.rs
+++ b/src/user_management/operations/authenticate_with_email_verification.rs
@@ -53,10 +53,10 @@ pub trait AuthenticateWithEmailVerification {
     /// ```
     /// # use std::{net::IpAddr, str::FromStr};
     ///
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::ClientId;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::ClientId;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), AuthenticateError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/authenticate_with_magic_auth.rs
+++ b/src/user_management/operations/authenticate_with_magic_auth.rs
@@ -56,10 +56,10 @@ pub trait AuthenticateWithMagicAuth {
     /// ```
     /// # use std::{net::IpAddr, str::FromStr};
     ///
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::ClientId;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::ClientId;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), AuthenticateError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/authenticate_with_password.rs
+++ b/src/user_management/operations/authenticate_with_password.rs
@@ -55,10 +55,10 @@ pub trait AuthenticateWithPassword {
     /// ```
     /// # use std::{net::IpAddr, str::FromStr};
     ///
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::ClientId;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::ClientId;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), AuthenticateError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/authenticate_with_refresh_token.rs
+++ b/src/user_management/operations/authenticate_with_refresh_token.rs
@@ -54,10 +54,10 @@ pub trait AuthenticateWithRefreshToken {
     /// ```
     /// # use std::{net::IpAddr, str::FromStr};
     ///
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::ClientId;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::ClientId;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), AuthenticateError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/authenticate_with_totp.rs
+++ b/src/user_management/operations/authenticate_with_totp.rs
@@ -57,11 +57,11 @@ pub trait AuthenticateWithTotp {
     /// ```
     /// # use std::{net::IpAddr, str::FromStr};
     ///
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::mfa::AuthenticationChallengeId;
-    /// # use workos_sdk::sso::ClientId;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::mfa::AuthenticationChallengeId;
+    /// # use workos::sso::ClientId;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), AuthenticateError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/create_magic_auth.rs
+++ b/src/user_management/operations/create_magic_auth.rs
@@ -35,9 +35,9 @@ pub trait CreateMagicAuth {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), CreateMagicAuthError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/create_password_reset.rs
+++ b/src/user_management/operations/create_password_reset.rs
@@ -73,9 +73,9 @@ pub trait CreatePasswordReset {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), CreatePasswordResetError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/create_user.rs
+++ b/src/user_management/operations/create_user.rs
@@ -51,9 +51,9 @@ pub trait CreateUser {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), CreateUserError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/delete_user.rs
+++ b/src/user_management/operations/delete_user.rs
@@ -32,9 +32,9 @@ pub trait DeleteUser {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), DeleteUserError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/enroll_auth_factor.rs
+++ b/src/user_management/operations/enroll_auth_factor.rs
@@ -107,9 +107,9 @@ pub trait EnrollAuthFactor {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), EnrollAuthFactorError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/find_invitation_by_token.rs
+++ b/src/user_management/operations/find_invitation_by_token.rs
@@ -24,9 +24,9 @@ pub trait FindInvitationByToken {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), FindInvitationByTokenError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_authorization_url.rs
+++ b/src/user_management/operations/get_authorization_url.rs
@@ -84,9 +84,9 @@ pub trait GetAuthorizationUrl {
     ///
     /// ```
     /// # use url::ParseError;
-    /// # use workos_sdk::sso::{ClientId, ConnectionId};
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::sso::{ClientId, ConnectionId};
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # fn run() -> Result<(), ParseError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_email_verification.rs
+++ b/src/user_management/operations/get_email_verification.rs
@@ -24,9 +24,9 @@ pub trait GetEmailVerification {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetEmailVerificationError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_invitation.rs
+++ b/src/user_management/operations/get_invitation.rs
@@ -24,9 +24,9 @@ pub trait GetInvitation {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetInvitationError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_jwks.rs
+++ b/src/user_management/operations/get_jwks.rs
@@ -22,10 +22,10 @@ pub trait GetJwks {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::sso::ClientId;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::sso::ClientId;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetJwksError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_jwks_url.rs
+++ b/src/user_management/operations/get_jwks_url.rs
@@ -13,9 +13,9 @@ pub trait GetJwksUrl {
     ///
     /// ```
     /// # use url::ParseError;
-    /// # use workos_sdk::sso::ClientId;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::sso::ClientId;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # fn run() -> Result<(), ParseError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_logout_url.rs
+++ b/src/user_management/operations/get_logout_url.rs
@@ -22,8 +22,8 @@ pub trait GetLogoutUrl {
     ///
     /// ```
     /// # use url::{ParseError, Url};
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # fn run() -> Result<(), ParseError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_magic_auth.rs
+++ b/src/user_management/operations/get_magic_auth.rs
@@ -24,9 +24,9 @@ pub trait GetMagicAuth {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetMagicAuthError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_password_reset.rs
+++ b/src/user_management/operations/get_password_reset.rs
@@ -24,9 +24,9 @@ pub trait GetPasswordReset {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetPasswordResetError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_user.rs
+++ b/src/user_management/operations/get_user.rs
@@ -24,9 +24,9 @@ pub trait GetUser {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetUserError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_user_by_external_id.rs
+++ b/src/user_management/operations/get_user_by_external_id.rs
@@ -24,9 +24,9 @@ pub trait GetUserByExternalId {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetUserByExternalIdError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/get_user_identities.rs
+++ b/src/user_management/operations/get_user_identities.rs
@@ -24,9 +24,9 @@ pub trait GetUserIdentities {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), GetUserIdentitiesError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/list_auth_factors.rs
+++ b/src/user_management/operations/list_auth_factors.rs
@@ -38,9 +38,9 @@ pub trait ListAuthFactors {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), ()> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/list_invitations.rs
+++ b/src/user_management/operations/list_invitations.rs
@@ -40,10 +40,10 @@ pub trait ListInvitations {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
-    /// use workos_sdk::organizations::OrganizationId;
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
+    /// use workos::organizations::OrganizationId;
     ///
     /// # async fn run() -> WorkOsResult<(), ListInvitationsError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/list_users.rs
+++ b/src/user_management/operations/list_users.rs
@@ -40,9 +40,9 @@ pub trait ListUsers {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), ListUsersError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/reset_password.rs
+++ b/src/user_management/operations/reset_password.rs
@@ -111,9 +111,9 @@ pub trait ResetPassword {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), ResetPasswordError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/revoke_invitation.rs
+++ b/src/user_management/operations/revoke_invitation.rs
@@ -24,9 +24,9 @@ pub trait RevokeInvitation {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), RevokeInvitationError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/send_invitation.rs
+++ b/src/user_management/operations/send_invitation.rs
@@ -47,9 +47,9 @@ pub trait SendInvitation {
     /// # Examples
     ///
     /// ```
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), SendInvitationError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));

--- a/src/user_management/operations/update_user.rs
+++ b/src/user_management/operations/update_user.rs
@@ -57,9 +57,9 @@ pub trait UpdateUser {
     /// ```
     /// use std::collections::HashMap;
     ///
-    /// # use workos_sdk::WorkOsResult;
-    /// # use workos_sdk::user_management::*;
-    /// use workos_sdk::{ApiKey, Metadata, WorkOs};
+    /// # use workos::WorkOsResult;
+    /// # use workos::user_management::*;
+    /// use workos::{ApiKey, Metadata, WorkOs};
     ///
     /// # async fn run() -> WorkOsResult<(), UpdateUserError> {
     /// let workos = WorkOs::new(&ApiKey::from("sk_example_123456789"));


### PR DESCRIPTION
Rename crate to [`workos`](https://crates.io/crates/workos). Please upgrade by changing the crate name in `Cargo.toml`:

```diff
- workos-sdk = "0.4.1"
+ workos = "0.5.0"
```
